### PR TITLE
Dockerize prosody

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN mkdir -p /usr/share/prosody/modules && \
 
 COPY --chown=prosody:prosody files/etc/prosody/prosody.cfg.lua /etc/prosody/prosody.cfg.lua
 
-VOLUME [ "/etc/prosody" ]
+VOLUME [ "/etc/prosody", "/var/lib/prosody" ]
 USER prosody
 
 EXPOSE 5222 5347 5280

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,52 @@
+FROM debian:10
+
+ARG JITSI_PROSODY_PLUGINS_VERSION=stable/jitsi-meet_5390
+
+# Upgrade system packages to install security updates and install dependencies
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y \
+      curl \
+      wget \
+      gettext-base \
+      gpg \
+      lua5.2 \
+      liblua5.2-dev \
+      libsasl2-dev \
+      libssl1.1 \
+      libssl-dev \
+      luarocks \
+      lua-event && \
+    luarocks install basexx 0.4.1-1 && \
+    luarocks install luajwtjitsi 2.0-0 && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install prosody
+RUN wget -q https://prosody.im/files/prosody-debian-packages.key -O - | gpg --enarmor > /etc/apt/trusted.gpg.d/prosody.asc \
+    && echo "deb http://packages.prosody.im/debian buster main" > /etc/apt/sources.list.d/prosody.list \
+    && apt-get update \
+    && apt-get install -y \
+      prosody && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /etc/prosody/conf.d && \
+    chown -R prosody. /etc/prosody
+      
+# Install prosody modules
+RUN mkdir -p /usr/share/prosody/modules && \
+    cd /tmp && \
+    mkdir jitsi-meet && \
+    curl -sLo jitsi-meet.tgz https://github.com/jitsi/jitsi-meet/archive/refs/tags/${JITSI_PROSODY_PLUGINS_VERSION}.tar.gz && \
+    tar xzf jitsi-meet.tgz -C jitsi-meet --strip-components 1 && \
+    cp -r ./jitsi-meet/resources/prosody-plugins/* /usr/share/prosody/modules && \
+    curl -so /usr/share/prosody/modules/mod_token_affiliation.lua https://raw.githubusercontent.com/emrahcom/emrah-buster-templates/6ae86bbff1459b669b311f3ec00946921cd683c9/machines/eb-jitsi/usr/share/jitsi-meet/prosody-plugins/mod_token_affiliation.lua && \
+    rm -rf jitsi-meet.tgz jitsi-meet && \
+    chown -R prosody. /usr/share/prosody/modules
+
+COPY --chown=prosody:prosody files/etc/prosody/prosody.cfg.lua /etc/prosody/prosody.cfg.lua
+
+VOLUME [ "/etc/prosody" ]
+USER prosody
+
+EXPOSE 5222 5347 5280
+
+CMD ["prosody", "-F"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 France Université Numérique
+Copyright (c) 2021-present GIP FUN MOOC.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Prosody Docker
+
+Docker image for [Prosody](https://prosody.im/) XMPP server.
+
+## Getting started
+
+To build this image run the following command:
+
+```bash
+$ docker build -r prosody:latest
+```
+
+Once build, you can tag it with the name you want and publish it on the docker repo you want.
+
+## Modules installed
+
+Some additionnal modules are installed on this image. They are available in `/usr/share/prosody/modules`.
+If you change the prosody config don't forget to include them if you want to use them: `plugin_paths = { "/usr/share/prosody/modules" }`
+
+All modules developed for [jitsi](https://meet.jit.si/) are installed. Also the [mod_token_affiliation](https://raw.githubusercontent.com/emrahcom/emrah-buster-templates/6ae86bbff1459b669b311f3ec00946921cd683c9/machines/eb-jitsi/usr/share/jitsi-meet/prosody-plugins/mod_token_affiliation.lua) module is installed.
+
+
+
+## License
+
+This work is released under the MIT License (see [LICENSE](./LICENSE)).
+
+

--- a/files/etc/prosody/prosody.cfg.lua
+++ b/files/etc/prosody/prosody.cfg.lua
@@ -1,0 +1,230 @@
+-- Prosody Example Configuration File
+--
+-- If it wasn't already obvious, -- starts a comment, and all 
+-- text after it on a line is ignored by Prosody.
+--
+-- The config is split into sections, a global section, and one 
+-- for each defined host that we serve. You can add as many host 
+-- sections as you like.
+--
+-- Lists are written
+-- _ = { "like", "this", "one" } 
+-- Lists can also be of { 1, 2, 3 } numbers, etc. 
+-- Either commas, or semi-colons; may be used
+-- as separators.
+--
+-- A table is a list of values, except each value has a name. An 
+-- example would be:
+--
+-- examlpe_ssl = { key = "keyfile.key", certificate = "certificate.crt" }
+--
+-- Whitespace (that is tabs, spaces, line breaks) is mostly insignificant, so 
+-- can 
+-- be placed anywhere
+-- that   you deem fitting.
+--
+-- Tip: You can check that the syntax of this file is correct
+-- when you have finished by running this command:
+--     prosodyctl check config
+-- If there are any errors, it will let you know what and where
+-- they are, otherwise it will keep quiet.
+--
+-- The only thing left to do is rename this file to remove the .dist ending, and fill in the
+-- blanks. Good luck, and happy Jabbering!
+
+
+---------- Server-wide settings ----------
+-- Settings in this section apply to the whole server and are the default settings
+-- for any virtual hosts
+
+-- This is a (by default, empty) list of accounts that are admins
+-- for the server. Note that you must create the accounts separately
+-- (see https://prosody.im/doc/creating_accounts for info)
+-- Example: admins = { "user1@example.com", "user2@example.net" }
+admins = { }
+
+-- The daemonize and pidfile are used to run prosody in foreground
+daemonize=false
+pidfile = "prosody.pid"
+
+-- Enable use of libevent for better performance under high load
+-- For more information see: https://prosody.im/doc/libevent
+use_libevent = true
+
+-- Prosody will always look in its source directory for modules, but
+-- this option allows you to specify additional locations where Prosody
+-- will look for modules first. For community modules, see https://modules.prosody.im/
+plugin_paths = { "/usr/share/prosody/modules" }
+
+cross_domain_bosh = true
+consider_bosh_secure = true
+-- This is the list of modules Prosody will load on startup.
+-- It looks for mod_modulename.lua in the plugins folder, so make sure that exists too.
+-- Documentation for bundled modules can be found at: https://prosody.im/doc/modules
+modules_enabled = {
+
+	-- Generally required
+		"roster"; -- Allow users to have a roster. Recommended ;)
+		"saslauth"; -- Authentication for clients and servers. Recommended if you want to log in.
+		"tls"; -- Add support for secure TLS on c2s/s2s connections
+		"dialback"; -- s2s dialback support
+		"disco"; -- Service discovery
+
+	-- Not essential, but recommended
+		"carbons"; -- Keep multiple clients in sync
+		"pep"; -- Enables users to publish their avatar, mood, activity, playing music and more
+		"private"; -- Private XML storage (for room bookmarks, etc.)
+		"blocklist"; -- Allow users to block communications with other users
+		"vcard4"; -- User profiles (stored in PEP)
+		"vcard_legacy"; -- Conversion between legacy vCard and PEP Avatar, vcard
+
+	-- Nice to have
+		"version"; -- Replies to server version requests
+		"uptime"; -- Report how long server has been running
+		"time"; -- Let others know the time here on this server
+		"ping"; -- Replies to XMPP pings with pongs
+		"register"; -- Allow users to register on this server using a client and change passwords
+		--"mam"; -- Store messages in an archive and allow users to access it
+		--"csi_simple"; -- Simple Mobile optimizations
+
+	-- Admin interfaces
+		"admin_adhoc"; -- Allows administration via an XMPP client that supports ad-hoc commands
+		--"admin_telnet"; -- Opens telnet console interface on localhost port 5582
+
+	-- HTTP modules
+		--"bosh"; -- Enable BOSH clients, aka "Jabber over HTTP"
+		--"websocket"; -- XMPP over WebSockets
+		--"http_files"; -- Serve static files from a directory over HTTP
+
+	-- Other specific functionality
+		--"limits"; -- Enable bandwidth limiting for XMPP connections
+		--"groups"; -- Shared roster support
+		--"server_contact_info"; -- Publish contact information for this service
+		--"announce"; -- Send announcement to all online users
+		--"welcome"; -- Welcome users who register accounts
+		--"watchregistrations"; -- Alert admins of registrations
+		--"motd"; -- Send a message to users when they log in
+		--"legacyauth"; -- Legacy authentication. Only used by some old clients and bots.
+		--"proxy65"; -- Enables a file transfer proxy service which clients behind NAT can use
+}
+
+-- These modules are auto-loaded, but should you want
+-- to disable them then uncomment them here:
+modules_disabled = {
+    -- "offline"; -- Store offline messages
+    -- "c2s"; -- Handle client connections
+    -- "s2s"; -- Handle server-to-server connections
+    -- "posix"; -- POSIX functionality, sends server to background, enables syslog, etc.
+}
+
+-- Disable account creation by default, for security
+-- For more information see https://prosody.im/doc/creating_accounts
+allow_registration = false
+
+-- Force clients to use encrypted connections? This option will
+-- prevent clients from authenticating unless they are using encryption.
+
+c2s_require_encryption = false
+
+-- Force servers to use encrypted connections? This option will
+-- prevent servers from authenticating unless they are using encryption.
+
+s2s_require_encryption = false
+
+-- Force certificate authentication for server-to-server connections?
+
+s2s_secure_auth = false
+
+-- Some servers have invalid or self-signed certificates. You can list
+-- remote domains here that will not be required to authenticate using
+-- certificates. They will be authenticated using DNS instead, even
+-- when s2s_secure_auth is enabled.
+
+--s2s_insecure_domains = { "insecure.example" }
+
+-- Even if you disable s2s_secure_auth, you can still require valid
+-- certificates for some domains by specifying a list here.
+
+--s2s_secure_domains = { "jabber.org" }
+
+-- Select the authentication backend to use. The 'internal' providers
+-- use Prosody's configured data storage to store the authentication data.
+
+authentication = "internal_hashed"
+
+-- Select the storage backend to use. By default Prosody uses flat files
+-- in its configured data directory, but it also supports more backends
+-- through modules. An "sql" backend is included by default, but requires
+-- additional dependencies. See https://prosody.im/doc/storage for more info.
+
+--storage = "sql" -- Default is "internal"
+
+-- For the "sql" backend, you can uncomment *one* of the below to configure:
+--sql = { driver = "SQLite3", database = "prosody.sqlite" } -- Default. 'database' is the filename.
+--sql = { driver = "MySQL", database = "prosody", username = "prosody", password = "secret", host = "localhost" }
+--sql = { driver = "PostgreSQL", database = "prosody", username = "prosody", password = "secret", host = "localhost" }
+
+
+-- Archiving configuration
+-- If mod_mam is enabled, Prosody will store a copy of every message. This
+-- is used to synchronize conversations between multiple clients, even if
+-- they are offline. This setting controls how long Prosody will keep
+-- messages in the archive before removing them.
+
+archive_expires_after = "1w" -- Remove archived messages after 1 week
+
+-- You can also configure messages to be stored in-memory only. For more
+-- archiving options, see https://prosody.im/doc/modules/mod_mam
+
+-- Logging configuration
+-- For advanced logging see https://prosody.im/doc/logging
+log = {
+    {levels = {min = "debug"}, to = "console"};
+}
+
+-- Uncomment to enable statistics
+-- For more info see https://prosody.im/doc/statistics
+-- statistics = "internal"
+
+-- Certificates
+-- Every virtual host and component needs a certificate so that clients and
+-- servers can securely verify its identity. Prosody will automatically load
+-- certificates/keys from the directory specified here.
+-- For more information, including how to use 'prosodyctl' to auto-import certificates
+-- (from e.g. Let's Encrypt) see https://prosody.im/doc/certificates
+
+-- Location of directory to find certificates in (relative to main config file):
+certificates = "certs"
+
+-- HTTPS currently only supports a single certificate, specify it here:
+--https_certificate = "certs/localhost.crt"
+
+----------- Virtual hosts -----------
+-- You need to add a VirtualHost entry for each domain you wish Prosody to serve.
+-- Settings under each VirtualHost entry apply *only* to that host.
+
+VirtualHost "localhost"
+
+--VirtualHost "example.com"
+--  certificate = "/path/to/example.crt"
+
+------ Components ------
+-- You can specify components to add hosts that provide special services,
+-- like multi-user conferences, and transports.
+-- For more information on components, see https://prosody.im/doc/components
+
+---Set up a MUC (multi-user chat) room server on conference.example.com:
+--Component "conference.example.com" "muc"
+--- Store MUC messages in an archive and allow users to access it
+--modules_enabled = { "muc_mam" }
+
+---Set up an external component (default component port is 5347)
+--
+-- External components allow adding various services, such as gateways/
+-- transports to other networks like ICQ, MSN and Yahoo. For more info
+-- see: https://prosody.im/doc/components#adding_an_external_component
+--
+--Component "gateway.example.com"
+--  component_secret = "password"
+
+Include "conf.d/*.cfg.lua"


### PR DESCRIPTION
## Purpose

We want to dockerize Prosody XMPP server. We need some additional
modules in this image: mod_token and mod_token_affiliation.

## Proposal

- [x] Create a Dockerfile installing prosody
- [x] Install additional modules: mod_token and mod_token_affiliation

