### PR TITLE
✨(docker) install dependencies to connect to postgres

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ RUN apt-get update && \
       libssl1.1 \
       libssl-dev \
       luarocks \
-      lua-event && \
+      lua-event \
+      lua-dbi-postgresql && \
     luarocks install basexx 0.4.1-1 && \
     luarocks install luajwtjitsi 2.0-0 && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
### Purpose

In order to connect to postgres databases, we need to install the
dependency lua-dbi-postgresql.

### Proposal

- [x] Install lua-dbi-postgresql dependency