### PR TITLE
✨(docker) add mod_muc_moderation support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN mkdir -p /usr/share/prosody/modules && \
     tar xzf jitsi-meet.tgz -C jitsi-meet --strip-components 1 && \
     cp -r ./jitsi-meet/resources/prosody-plugins/* /usr/share/prosody/modules && \
     curl -so /usr/share/prosody/modules/mod_token_affiliation.lua https://raw.githubusercontent.com/emrahcom/emrah-buster-templates/6ae86bbff1459b669b311f3ec00946921cd683c9/machines/eb-jitsi/usr/share/jitsi-meet/prosody-plugins/mod_token_affiliation.lua && \
+    curl -so /usr/share/prosody/modules/mod_muc_moderation.lua https://hg.prosody.im/prosody-modules/raw-file/5f12c75fd210/mod_muc_moderation/mod_muc_moderation.lua && \
     rm -rf jitsi-meet.tgz jitsi-meet && \
     chown -R prosody. /usr/share/prosody/modules
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Docker image for [Prosody](https://prosody.im/) XMPP server.
 To build this image run the following command:
 
 ```bash
-$ docker build -r prosody:latest
+$ docker build -t prosody:latest
 ```
 
 Once build, you can tag it with the name you want and publish it on the docker repo you want.
@@ -18,11 +18,10 @@ Some additionnal modules are installed on this image. They are available in `/us
 If you change the prosody config don't forget to include them if you want to use them: `plugin_paths = { "/usr/share/prosody/modules" }`
 
 All modules developed for [jitsi](https://meet.jit.si/) are installed. Also the [mod_token_affiliation](https://raw.githubusercontent.com/emrahcom/emrah-buster-templates/6ae86bbff1459b669b311f3ec00946921cd683c9/machines/eb-jitsi/usr/share/jitsi-meet/prosody-plugins/mod_token_affiliation.lua) module is installed.
+We also have the [mod_muc_moderation](https://hg.prosody.im/prosody-modules/raw-file/5f12c75fd210/mod_muc_moderation/mod_muc_moderation.lua) module installed, in order to bring XEP-0425: Message Moderation support to prosody.
 
 
 
 ## License
 
 This work is released under the MIT License (see [LICENSE](./LICENSE)).
-
-


### PR DESCRIPTION
Add mod_muc_moderation download in the dedicated RUN command in docker, in
order to bring XEP-0425: Message Moderation support to prosody.